### PR TITLE
Refactor to trait

### DIFF
--- a/config/fingerprints.php
+++ b/config/fingerprints.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'model' => env('FINGERPRINT_MODEL', 'App\User'),
+];

--- a/src/FingerprintServiceProvider.php
+++ b/src/FingerprintServiceProvider.php
@@ -15,6 +15,10 @@ class FingerprintServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->addMigrationMacros();
+
+        $this->publishes([
+            __DIR__ . '/../config/fingerprints.php' => config_path('fingerprints.php'),
+        ], 'config');
     }
 
     /**

--- a/src/TrackableModel.php
+++ b/src/TrackableModel.php
@@ -2,13 +2,15 @@
 
 namespace RickyJohnston\Fingerprints;
 
-use App\User;
 use Illuminate\Database\Eloquent\Model;
 use RickyJohnston\Fingerprints\Events\ModelCreated;
 use RickyJohnston\Fingerprints\Events\ModelUpdated;
+use RickyJohnston\Fingerprints\Traits\Forensics;
 
 abstract class TrackableModel extends Model
 {
+    use Forensics;
+
     /**
      * The event map for the model.
      *
@@ -18,14 +20,4 @@ abstract class TrackableModel extends Model
         'created' => ModelCreated::class,
         'updated' => ModelUpdated::class,
     ];
-
-    public function creator()
-    {
-        return $this->hasOne(User::class, 'id', 'created_by');
-    }
-
-    public function updater()
-    {
-        return $this->hasOne(User::class, 'id', 'updated_by');
-    }
 }

--- a/src/Traits/Forensics.php
+++ b/src/Traits/Forensics.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace RickyJohnston\Fingerprints\Traits;
+
+trait Forensics
+{
+    /**
+     * The owning model has a creator
+     */
+    public function creator()
+    {
+        return $this->hasOne(\App\User::class, 'id', 'created_by');
+    }
+
+    /**
+     * The owning model has an updater
+     */
+    public function updater()
+    {
+        return $this->hasOne(\App\User::class, 'id', 'updated_by');
+    }
+}

--- a/src/Traits/Forensics.php
+++ b/src/Traits/Forensics.php
@@ -9,7 +9,7 @@ trait Forensics
      */
     public function creator()
     {
-        return $this->hasOne(\App\User::class, 'id', 'created_by');
+        return $this->hasOne(config('fingerprints.model'), 'id', 'created_by');
     }
 
     /**
@@ -17,6 +17,6 @@ trait Forensics
      */
     public function updater()
     {
-        return $this->hasOne(\App\User::class, 'id', 'updated_by');
+        return $this->hasOne(config('fingerprints.model'), 'id', 'updated_by');
     }
 }


### PR DESCRIPTION
This PR refactors the model relationships in the abstract model to a Trait, which can be used outside the scope of that abstract class if the consumer wished to avoid using an event-based approach.